### PR TITLE
add format_log for :find

### DIFF
--- a/lib/mongo_ecto.ex
+++ b/lib/mongo_ecto.ex
@@ -749,6 +749,10 @@ defmodule Mongo.Ecto do
     ["FIND", format_part("coll", coll), format_part("query", query),
      format_part("projection", projection)]
   end
+  defp format_log(_entry, :find, [coll, query, projection, _opts]) do
+    ["FIND", format_part("coll", coll), format_part("query", query),
+     format_part("projection", projection)]
+  end
   defp format_log(_entry, :find_batch, [coll, cursor, _opts]) do
     ["GET_MORE", format_part("coll", coll), format_part("cursor_id", cursor)]
   end

--- a/lib/mongo_ecto.ex
+++ b/lib/mongo_ecto.ex
@@ -745,15 +745,11 @@ defmodule Mongo.Ecto do
     ["UPDATE", format_part("coll", coll), format_part("filter", filter),
      format_part("update", update), format_part("many", true)]
   end
-  defp format_log(_entry, :find_cursor, [coll, query, projection, _opts]) do
-    ["FIND", format_part("coll", coll), format_part("query", query),
-     format_part("projection", projection)]
-  end
   defp format_log(_entry, :find, [coll, query, projection, _opts]) do
     ["FIND", format_part("coll", coll), format_part("query", query),
      format_part("projection", projection)]
   end
-  defp format_log(_entry, :find_batch, [coll, cursor, _opts]) do
+  defp format_log(_entry, :find_rest, [coll, cursor, _opts]) do
     ["GET_MORE", format_part("coll", coll), format_part("cursor_id", cursor)]
   end
   defp format_log(_entry, :kill_cursors, [cursors, _opts]) do


### PR DESCRIPTION
This is my first time working with Ecto, so I'm not sure if I performed the query correctly, but I received an error message saying no function clause matching Mongo.Ecto.format_log for :find.
