### PR TITLE
Correctly load an empty map as a map

### DIFF
--- a/lib/mongo_ecto.ex
+++ b/lib/mongo_ecto.ex
@@ -398,6 +398,8 @@ defmodule Mongo.Ecto do
     do: Ecto.Type.load(ObjectID, data, &load/2)
   def load(Ecto.Date, {date, _time}),
     do: Ecto.Type.load(Ecto.Date, date, &dump/2)
+  def load(:map, []),
+    do: {:ok, %{}}
   def load(type, data),
     do: Ecto.Type.load(type, data, &load/2)
 

--- a/test/mongo_ecto_test.exs
+++ b/test/mongo_ecto_test.exs
@@ -109,4 +109,12 @@ defmodule Mongo.EctoTest do
     [item] = TestRepo.get!(Tag, tag.id).items
     assert item.price == 10
   end
+
+  test "decode empty map to map" do
+    post = TestRepo.insert!(%Post{meta: %{}})
+    assert post.meta == %{}
+
+    post = TestRepo.get(Post, post.id)
+    assert post.meta == %{}
+  end
 end


### PR DESCRIPTION
Because the driver decodes documents as lists an empty document has the same representation as an empty array.