### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For additional information on usage please see the documentation for [Ecto](http
 |   binary data (uuid)  |`Ecto.UUID`|
 |   object id           |`:binary_id`|
 |   boolean             |`:boolean`|
-|   date                |`:datetime`|
+|   date                |`Ecto.DateTime`|
 |   regular expression  |`Mongo.Ecto.Regex`|
 |   JavaScript          |`Mongo.Ecto.JavaScript`|
 |   symbol              |(see below)|


### PR DESCRIPTION
Is Ecto.DateTime the new way to represent datetime?

Using `datetime` gives me:

`* (ArgumentError) invalid or unknown type :datetime for field :sent_at. Maybe you meant to use Ecto.DateTime as the type?`