### PR TITLE
Mongo32 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ env:
     - MONGOVERSION=2.4.14
     - MONGOVERSION=2.6.11
     - MONGOVERSION=3.0.7
+    - MONGOVERSION=3.2.3
 
 script:
   - mix test

--- a/lib/mongo_ecto/connection.ex
+++ b/lib/mongo_ecto/connection.ex
@@ -134,8 +134,8 @@ defmodule Mongo.Ecto.Connection do
     end
   end
 
-  defp constraint(msg) do
-    case String.split(msg, [".$", " dup "]) do
+  def constraint(msg) do
+    case String.split(msg, [".$", "index: ", " dup "]) do
       [_, name, _] ->
         [unique: String.strip(name)]
       _other ->

--- a/test/mongo_ecto/migrations_test.exs
+++ b/test/mongo_ecto/migrations_test.exs
@@ -105,6 +105,14 @@ defmodule Mongo.Ecto.MigrationsTest do
 
   import Ecto.Migrator, only: [up: 4, down: 4]
 
+  test "listCollections shouldn't include schema collection" do
+    TestRepo.insert! %RenameModel{to_be_renamed: 1}
+
+    assert !Enum.member?(Mongo.Ecto.list_collections(TestRepo), Ecto.Migration.SchemaMigration.__schema__(:source))
+
+    Mongo.Ecto.truncate(TestRepo)
+  end
+
   test "create and drop indexes" do
     assert :ok == up(TestRepo, 20050906120000, CreateMigration, log: false)
     assert :ok == down(TestRepo, 20050906120000, CreateMigration, log: false)


### PR DESCRIPTION
Fixed truncate (system.namespaces are depracated in favor of listCollections command) and handling constraint matching differently to have tests passing properly 