### PR TITLE
Fix compiler warnings on functions `transaction/3` and `rollback/2`

### DIFF
--- a/lib/mongo_ecto.ex
+++ b/lib/mongo_ecto.ex
@@ -770,12 +770,12 @@ defmodule Mongo.Ecto do
 
   @doc false
   def transaction(_, _, _) do
-    :ok
+    raise "transactions are not supported"
   end
 
   @doc false
   def rollback(_, _) do
-    :ok
+    raise "transactions are not supported"
   end
 
   defp list_collections(version, repo, opts) when version >= 3 do

--- a/lib/mongo_ecto.ex
+++ b/lib/mongo_ecto.ex
@@ -766,6 +766,18 @@ defmodule Mongo.Ecto do
     list_collections(db_version(repo), repo, opts)
   end
 
+  # The two functions, just to stop compiler warnings
+
+  @doc false
+  def transaction(_, _, _) do
+    :ok
+  end
+
+  @doc false
+  def rollback(_, _) do
+    :ok
+  end
+
   defp list_collections(version, repo, opts) when version >= 3 do
     colls = command(repo, %{"listCollections": 1}, opts)["cursor"]["firstBatch"]
 


### PR DESCRIPTION
Compiler always warns about those two functions when compiling projects using this adapter. This fixes the warnings.