### PR TITLE
Fixed a compiler warning about unsafe variable usage

### DIFF
--- a/lib/mongo_ecto/normalized_query.ex
+++ b/lib/mongo_ecto/normalized_query.ex
@@ -78,9 +78,9 @@ defmodule Mongo.Ecto.NormalizedQuery do
         {:skip,  value} -> ["$skip":  value]
       end)
       |> Kernel.++(pipeline)
-      |> (fn pipeline -> if query != %{}, do: [["$match": query] | pipeline], else: pipeline end).()
+      |> aggregate_pipeline(query)
 
-      %AggregateQuery{coll: coll, pipeline: pipeline, pk: pk, fields: fields,
+    %AggregateQuery{coll: coll, pipeline: pipeline, pk: pk, fields: fields,
                       database: original.prefix}
   end
 
@@ -132,6 +132,14 @@ defmodule Mongo.Ecto.NormalizedQuery do
 
   defp from(%Query{from: {coll, model}}) do
     {coll, model, primary_key(model)}
+  end
+
+  defp aggregate_pipeline(pipeline, query) do
+    if query != %{} do
+      [["$match": query] | pipeline]
+    else
+      pipeline
+    end
   end
 
   @aggregate_ops [:min, :max, :sum, :avg]

--- a/lib/mongo_ecto/normalized_query.ex
+++ b/lib/mongo_ecto/normalized_query.ex
@@ -78,13 +78,10 @@ defmodule Mongo.Ecto.NormalizedQuery do
         {:skip,  value} -> ["$skip":  value]
       end)
       |> Kernel.++(pipeline)
+      |> (fn pipeline -> if query != %{}, do: [["$match": query] | pipeline], else: pipeline end).()
 
-    if query != %{} do
-      pipeline = [["$match": query] | pipeline]
-    end
-
-    %AggregateQuery{coll: coll, pipeline: pipeline, pk: pk, fields: fields,
-                    database: original.prefix}
+      %AggregateQuery{coll: coll, pipeline: pipeline, pk: pk, fields: fields,
+                      database: original.prefix}
   end
 
   def update_all(%Query{} = original, params) do


### PR DESCRIPTION
The warning is at `lib/mongo_ecto/normalized_query.ex:86`, and the variable `pipeline`.

I fixed it by using an anonymous function at the end of pipe operator. 