### PR TITLE
Fix bug where an empty map would be stored as an empty array.

### DIFF
--- a/lib/mongo_ecto/conversions.ex
+++ b/lib/mongo_ecto/conversions.ex
@@ -50,9 +50,13 @@ defmodule Mongo.Ecto.Conversions do
     do: :error
 
   defp document(doc, pk) do
-    map(doc, fn {key, value} ->
-      pair(key, value, pk, &from_ecto_pk(&1, pk))
-    end)
+    if is_map(doc) && map_size(doc) == 0 do
+      {:ok, %{}}
+    else
+      map(doc, fn {key, value} ->
+        pair(key, value, pk, &from_ecto_pk(&1, pk))
+      end)
+    end
   end
 
   defp document(doc, params, pk) do

--- a/lib/mongo_ecto/conversions.ex
+++ b/lib/mongo_ecto/conversions.ex
@@ -49,16 +49,13 @@ defmodule Mongo.Ecto.Conversions do
   def from_ecto_pk(_value, _pk),
     do: :error
 
+  defp document(doc, _pk) when is_map(doc) and map_size(doc) == 0,
+    do: {:ok, %{}}
   defp document(doc, pk) do
-    if is_map(doc) && map_size(doc) == 0 do
-      {:ok, %{}}
-    else
-      map(doc, fn {key, value} ->
-        pair(key, value, pk, &from_ecto_pk(&1, pk))
-      end)
-    end
+    map(doc, fn {key, value} ->
+      pair(key, value, pk, &from_ecto_pk(&1, pk))
+    end)
   end
-
   defp document(doc, params, pk) do
     map(doc, fn {key, value} ->
       pair(key, value, pk, &inject_params(&1, params, pk))

--- a/test/mongo_ecto/normalized_query_test.exs
+++ b/test/mongo_ecto/normalized_query_test.exs
@@ -10,6 +10,7 @@ defmodule Mongo.Ecto.NormalizedQueryTest do
     use Ecto.Model
 
     schema "model" do
+      field :m, :map
       field :x, :integer
       field :y, :integer, default: 5
       field :z, {:array, :integer}
@@ -42,7 +43,7 @@ defmodule Mongo.Ecto.NormalizedQueryTest do
   test "bare model" do
     query = Model |> from |> normalize
     assert_query(query, coll: "model", query: %{},
-                 projection: %{_id: true, x: true, y: true, z: true},
+                 projection: %{_id: true, x: true, y: true, z: true, m: true},
                  opts: [])
     assert [{:&, _, _}] = query.fields
   end
@@ -79,11 +80,13 @@ defmodule Mongo.Ecto.NormalizedQueryTest do
     assert [{:field, :x, _}, {:field, :y, _}] = query.fields
 
     query = Model |> select([r], [r, r.x]) |> normalize
-    assert_query(query, projection: %{_id: true, x: true, y: true, z: true})
+    assert_query(query, projection: %{_id: true, x: true, y: true, z: true, m:
+               true})
     assert [{:&, _, _}, {:field, :x, _}] = query.fields
 
     query = Model |> select([r], [r]) |> normalize
-    assert_query(query, projection: %{_id: true, x: true, y: true, z: true})
+    assert_query(query, projection: %{_id: true, x: true, y: true, z: true, m:
+               true})
     assert [{:&, _, _}] = query.fields
 
     query = Model |> select([r], {1}) |> normalize
@@ -95,7 +98,8 @@ defmodule Mongo.Ecto.NormalizedQueryTest do
     assert [{:field, :id, _}] = query.fields
 
     query = from(r in Model) |> normalize
-    assert_query(query, projection: %{_id: true, x: true, y: true, z: true})
+    assert_query(query, projection: %{_id: true, x: true, y: true, z: true, m:
+               true})
     assert [{:&, _, _}] = query.fields
   end
 
@@ -441,7 +445,7 @@ defmodule Mongo.Ecto.NormalizedQueryTest do
     query = Model |> insert(x: nil, y: nil, z: nil)
     assert_query(query, command: [y: nil, z: nil])
 
-    query = Model |> insert(x: 1, y: 5, z: [])
-    assert_query(query, command: [x: 1, y: 5, z: []])
+    query = Model |> insert(x: 1, y: 5, z: [], m: %{})
+    assert_query(query, command: [x: 1, y: 5, z: [], m: %{}])
   end
 end

--- a/test/mongo_ecto/normalized_query_test.exs
+++ b/test/mongo_ecto/normalized_query_test.exs
@@ -80,13 +80,11 @@ defmodule Mongo.Ecto.NormalizedQueryTest do
     assert [{:field, :x, _}, {:field, :y, _}] = query.fields
 
     query = Model |> select([r], [r, r.x]) |> normalize
-    assert_query(query, projection: %{_id: true, x: true, y: true, z: true, m:
-               true})
+    assert_query(query, projection: %{_id: true, x: true, y: true, z: true, m: true})
     assert [{:&, _, _}, {:field, :x, _}] = query.fields
 
     query = Model |> select([r], [r]) |> normalize
-    assert_query(query, projection: %{_id: true, x: true, y: true, z: true, m:
-               true})
+    assert_query(query, projection: %{_id: true, x: true, y: true, z: true, m: true})
     assert [{:&, _, _}] = query.fields
 
     query = Model |> select([r], {1}) |> normalize
@@ -98,8 +96,7 @@ defmodule Mongo.Ecto.NormalizedQueryTest do
     assert [{:field, :id, _}] = query.fields
 
     query = from(r in Model) |> normalize
-    assert_query(query, projection: %{_id: true, x: true, y: true, z: true, m:
-               true})
+    assert_query(query, projection: %{_id: true, x: true, y: true, z: true, m: true})
     assert [{:&, _, _}] = query.fields
   end
 


### PR DESCRIPTION
Hi, I noticed this issue after trying to store an empty map in a local Mongo.

The fix I propose here was done quickly so it may not fit perfectly with the current code base. Of course, any and all suggestions or comments are welcome.