### PR TITLE
Fix pattern matching error when creating uniqueness index

### DIFF
--- a/lib/mongo_ecto.ex
+++ b/lib/mongo_ecto.ex
@@ -650,8 +650,10 @@ defmodule Mongo.Ecto do
 
     query = %WriteQuery{coll: "system.indexes", command: index}
 
-    {:ok, _} = Connection.insert(repo, query, opts)
-    :ok
+    case Connection.insert(repo, query, opts) do
+      {:ok, _} -> :ok
+      {:invalid, [unique: index]} -> raise Connection.format_constraint_error(index)
+    end
   end
 
   def execute_ddl(repo, {:drop, %Index{name: name, table: coll}}, opts) do

--- a/lib/mongo_ecto/connection.ex
+++ b/lib/mongo_ecto/connection.ex
@@ -171,21 +171,26 @@ defmodule Mongo.Ecto.Connection do
   defp log_result({:ok, _query, res}), do: {:ok, res}
   defp log_result(other), do: other
 
-  defp check_constraint_errors(%Mongo.Error{code: code, message: msg} = error) do
-    msg =
-      ~r/(?<coll>[\w_]+\.[\w_]+)\.\$(?<index>[\w_]+).+\"(?<value>.+)\"/
-      |> Regex.named_captures(msg)
-      |> Map.merge(%{"code" => code})
-      |> constraint_error_template
-    raise %Mongo.Error{message: msg}
+  defp check_constraint_errors(%Mongo.Error{code: 11000, message: msg}) do
+    {:invalid, [unique: extract_index(msg)]}
   end
-  defp check_constraint_errors(other), do: raise other
+  defp check_constraint_errors(other) do
+    raise other
+  end
 
-  defp constraint_error_template(%{"coll" => coll, "index" => index, "value" => value, "code" => code}) do
-    "ERROR (#{code}): could not create unique index \"#{index}\"\n\n"
-     <> "collection: #{coll}\n"
-     <> "constraint: #{index}\n"
-     <> "duplicated value: #{value}\n"
+  defp extract_index(msg) do
+    parts = String.split(msg, [".$", "index: ", " dup "])
+
+    case Enum.reverse(parts) do
+      [_, index | _] ->
+        String.strip(index)
+      _  ->
+        raise "failed to extract index from error message: #{inspect msg}"
+    end
+  end
+
+  def format_constraint_error(index) do
+    %Mongo.Error{message: "ERROR (#{11000}): could not create unique index \"#{index}\" due to duplicated entry"}
   end
 
   defp format_query(%Query{action: :command}, [command]) do

--- a/lib/mongo_ecto/connection.ex
+++ b/lib/mongo_ecto/connection.ex
@@ -190,7 +190,7 @@ defmodule Mongo.Ecto.Connection do
   end
 
   def format_constraint_error(index) do
-    %Mongo.Error{message: "ERROR (#{11000}): could not create unique index \"#{index}\" due to duplicated entry"}
+    %Mongo.Error{message: "ERROR (11000): could not create unique index \"#{index}\" due to duplicated entry"}
   end
 
   defp format_query(%Query{action: :command}, [command]) do


### PR DESCRIPTION
Closes #111

Fixes a [pattern matching error](https://github.com/michalmuskala/mongodb_ecto/blob/ecto-2/lib/mongo_ecto.ex#L653) when trying to create a uniqueness index which contains duplicated values already stored in the database. The goal of this PR is also to make the uniqueness error message clearer, leading devs to a quick fix.

I checked how's the error message raised by `ecto`:

```
05:56:53.089 [error] GenServer UserService.Repo terminating
** (Postgrex.Error) ERROR 23505 (unique_violation): could not create unique index "users_email_index"

    table: users
    constraint: users_email_index

Key (email)=(tiagopog@gmail.com) is duplicated.
    (ecto) lib/ecto/adapters/sql.ex:195: Ecto.Adapters.SQL.query!/5
    (ecto) lib/ecto/adapters/postgres.ex:86: anonymous fn/4 in Ecto.Adapters.Postgres.execute_ddl/3
    (elixir) lib/enum.ex:1623: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ecto) lib/ecto/adapters/postgres.ex:86: Ecto.Adapters.Postgres.execute_ddl/3
    (ecto) lib/ecto/migration/runner.ex:98: anonymous fn/2 in Ecto.Migration.Runner.flush/0
    (elixir) lib/enum.ex:1623: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ecto) lib/ecto/migration/runner.ex:96: Ecto.Migration.Runner.flush/0
    (stdlib) timer.erl:181: :timer.tc/2
Last message: {:EXIT, #PID<0.71.0>, {%Postgrex.Error{connection_id: 85, message: nil, postgres: %{code: :unique_violation, constraint: "users_email_index", detail: "Key (email)=(tiagopog@gmail.com) is duplicated.", file: "tuplesort.c", line: "3271", message: "could not create unique index \"users_email_index\"", pg_code: "23505", routine: "comparetup_index_btree", schema: "public", severity: "ERROR", table: "users"}}, [{Ecto.Adapters.SQL, :query!, 5, [file: 'lib/ecto/adapters/sql.ex', line: 195]}, {Ecto.Adapters.Postgres, :"-execute_ddl/3-fun-0-", 4, [file: 'lib/ecto/adapters/postgres.ex', line: 86]}, {Enum, :"-reduce/3-lists^foldl/2-0-", 3, [file: 'lib/enum.ex', line: 1623]}, {Ecto.Adapters.Postgres, :execute_ddl, 3, [file: 'lib/ecto/adapters/postgres.ex', line: 86]}, {Ecto.Migration.Runner, :"-flush/0-fun-1-", 2, [file: 'lib/ecto/migration/runner.ex', line: 98]}, {Enum, :"-reduce/3-lists^foldl/2-0-", 3, [file: 'lib/enum.ex', line: 1623]}, {Ecto.Migration.Runner, :flush, 0, [file: 'lib/ecto/migration/runner.ex', line: 96]}, {:timer, :tc, 2, [file: 'timer.erl', line: 181]}]}}
State: {:state, {:local, UserService.Repo}, :one_for_one, [{:child, #PID<0.171.0>, DBConnection.Poolboy, {:poolboy, :start_link, [[name: {:local, UserService.Repo.Pool}, strategy: :fifo, size: 1, max_overflow: 0, worker_module: DBConnection.Poolboy.Worker], {Postgrex.Protocol, [types: Ecto.Adapters.Postgres.TypeModule, port: 5432, name: UserService.Repo.Pool, otp_app: :user_service, repo: UserService.Repo, adapter: Ecto.Adapters.Postgres, database: "user_service", username: "postgres", password: "postgres", hostname: "postgres", pool_size: 1, pool_timeout: 5000, timeout: 15000, adapter: Ecto.Adapters.Postgres, database: "user_service", username: "postgres", password: "postgres", hostname: "postgres", pool: DBConnection.Poolboy]}]}, :permanent, 5000, :worker, [:poolboy]}], :undefined, 3, 5, [], 0, Ecto.Repo.Supervisor, {UserService.Repo, :user_service, Ecto.Adapters.Postgres, [pool_size: 1]}}
``` 

And then I tried to bring something similar to `mongodb_ecto`:

```
21:09:45.600 [error] GenServer UserService.Repo terminating
** (Mongo.Error) ERROR (11000): could not create unique index "users_email_index"

collection: user_service.users
constraint: users_email_index
duplicated value: tiagopog@gmail.com

    lib/mongo_ecto/connection.ex:180: Mongo.Ecto.Connection.check_constraint_errors/1
    lib/mongo_ecto.ex:655: Mongo.Ecto.execute_ddl/3
    (ecto) lib/ecto/migration/runner.ex:101: anonymous fn/2 in Ecto.Migration.Runner.flush/0
    (elixir) lib/enum.ex:1623: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ecto) lib/ecto/migration/runner.ex:99: Ecto.Migration.Runner.flush/0
    (stdlib) timer.erl:181: :timer.tc/2
    (ecto) lib/ecto/migration/runner.ex:27: Ecto.Migration.Runner.run/6
    (ecto) lib/ecto/migrator.ex:121: Ecto.Migrator.attempt/6
Last message: {:EXIT, #PID<0.71.0>, {%Mongo.Error{code: nil, message: "ERROR (11000): could not create unique index \"users_email_index\"\n\ncollection: user_service.users\nconstraint: users_email_index\nduplicated value: tiagopog@gmail.com\n"}, [{Mongo.Ecto.Connection, :check_constraint_errors, 1, [file: 'lib/mongo_ecto/connection.ex', line: 180]}, {Mongo.Ecto, :execute_ddl, 3, [file: 'lib/mongo_ecto.ex', line: 655]}, {Ecto.Migration.Runner, :"-flush/0-fun-1-", 2, [file: 'lib/ecto/migration/runner.ex', line: 101]}, {Enum, :"-reduce/3-lists^foldl/2-0-", 3, [file: 'lib/enum.ex', line: 1623]}, {Ecto.Migration.Runner, :flush, 0, [file: 'lib/ecto/migration/runner.ex', line: 99]}, {:timer, :tc, 2, [file: 'timer.erl', line: 181]}, {Ecto.Migration.Runner, :run, 6, [file: 'lib/ecto/migration/runner.ex', line: 27]}, {Ecto.Migrator, :attempt, 6, [file: 'lib/ecto/migrator.ex', line: 121]}]}}
State: {:state, {:local, UserService.Repo}, :one_for_one, [{:child, #PID<0.351.0>, DBConnection.Connection, {DBConnection.Connection, :start_link, [Mongo.Protocol, [name: UserService.Repo.Pool, otp_app: :user_service, repo: UserService.Repo, database: "user_service", hostname: "user-service-db", pool_size: 1, pool_timeout: 5000, timeout: 15000, database: "user_service", hostname: "user-service-db"], :connection]}, :permanent, 5000, :worker, [DBConnection.Connection]}], :undefined, 3, 5, [], 0, Ecto.Repo.Supervisor, {UserService.Repo, :user_service, Mongo.Ecto, [otp_app: :user_service, repo: UserService.Repo, database: "user_service", hostname: "user-service-db", pool_size: 1]}}
```

Hope this helps :-)