### PR TITLE
mongodb_ecto #ecto-2 for phoenix

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule Mongo.Ecto.Mixfile do
   defp deps do
     [
       {:mongodb, "~> 0.2.0"},
-      {:ecto, "~> 2.0.0", github: "elixir-ecto/ecto", ref: "v2.0.6"},
+      # {:ecto, "~> 2.0.0", github: "elixir-ecto/ecto", ref: "v2.0.6"},
+      {:ecto, "~> 2.0"}, # should match phoenix_ecto
       {:dialyze, "~> 0.2.0", only: :dev},
       {:inch_ex, "~> 0.5", only: :docs},
       {:earmark, "~> 1.0", only: :docs},

--- a/mix.exs
+++ b/mix.exs
@@ -21,8 +21,7 @@ defmodule Mongo.Ecto.Mixfile do
   defp deps do
     [
       {:mongodb, "~> 0.2.0"},
-      # {:ecto, "~> 2.0.0", github: "elixir-ecto/ecto", ref: "v2.0.6"},
-      {:ecto, "~> 2.0"}, # should match phoenix_ecto
+      {:ecto, "~> 2.0"}, # should match phoenix_ecto@v3.0.1
       {:dialyze, "~> 0.2.0", only: :dev},
       {:inch_ex, "~> 0.5", only: :docs},
       {:earmark, "~> 1.0", only: :docs},

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Mongo.Ecto.Mixfile do
   defp deps do
     [
       {:mongodb, "~> 0.2.0"},
-      {:ecto, "~> 2.0.0", github: "elixir-ecto/ecto", ref: "v2.0"},
+      {:ecto, "~> 2.0.0", github: "elixir-ecto/ecto", ref: "v2.0.1"},
       {:dialyze, "~> 0.2.0", only: :dev},
       {:inch_ex, "~> 0.5", only: :docs},
       {:earmark, "~> 1.0", only: :docs},

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Mongo.Ecto.Mixfile do
   defp deps do
     [
       {:mongodb, "~> 0.2.0"},
-      {:ecto, "~> 2.0.0", github: "elixir-ecto/ecto", ref: "v2.0.1"},
+      {:ecto, "~> 2.0.0", github: "elixir-ecto/ecto", ref: "v2.0.6"},
       {:dialyze, "~> 0.2.0", only: :dev},
       {:inch_ex, "~> 0.5", only: :docs},
       {:earmark, "~> 1.0", only: :docs},


### PR DESCRIPTION
There were version conflicts, I had to fight a bit, but this seems to pass `deps.get` 

it now builds ok for an "old" version of phoenix:

https://github.com/zeroasterisk/example-elixir-meteor-api/blob/master/mix.exs#L41-L43

```ex
     # the mongodb_ecto & phoenix_ecto, both need to require same {:ecto, "~> 2.0"}
     {:phoenix_ecto, github: "phoenixframework/phoenix_ecto", ref: "v3.0.1"},
     {:mongodb_ecto, github: "zeroasterisk/mongodb_ecto", branch: "elixir-ecto-v2.0.1"},
```

re #127