### PR TITLE
Add wire_version support

### DIFF
--- a/lib/mongo_ecto/connection.ex
+++ b/lib/mongo_ecto/connection.ex
@@ -253,6 +253,9 @@ defmodule Mongo.Ecto.Connection do
   defp format_query(%Query{action: :kill_cursors, extra: coll}, []) do
     ["KILL_CURSORS", format_part("cursor_ids", "")]
   end
+  defp format_query(%Query{action: :wire_version, extra: coll}, []) do
+    ["WIRE_VERSION", format_part("cursor_ids", "")]
+  end
 
   defp format_part(name, value) do
     [" ", name, "=" | inspect(value)]


### PR DESCRIPTION
``` 
no function clause matching in Mongo.Ecto.Connection.format_query/2
    (mongodb_ecto) lib/mongo_ecto/connection.ex:196: Mongo.Ecto.Connection.format_query(%Mongo.Query{action: :wire_version, encoded?: false, extra: nil}, [])
```